### PR TITLE
Move camera system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,11 @@ fn main() {
         .add_startup_system(setup::create_actors)
         .add_plugins(DefaultPlugins)
         .add_system(get_entity)
-        .add_system(systems::camera::rotate_camera)
+        .add_system(
+            systems::camera::rotate_camera
+                .before(systems::camera::move_camera)
+        )
+        .add_system(systems::camera::move_camera)
         .add_system(systems::movement::keyboard_input)
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,7 @@ use setup::actor_types::Player;
 mod setup;
 mod systems;
 
-fn get_entity(
-    player: Res<Player>
-) {
+fn get_entity(player: Res<Player>) {
     println!("Found Player! {}", player.0.to_bits());
 }
 
@@ -14,10 +12,7 @@ fn main() {
         .add_startup_system(setup::create_actors)
         .add_plugins(DefaultPlugins)
         .add_system(get_entity)
-        .add_system(
-            systems::camera::rotate_camera
-                .before(systems::camera::move_camera)
-        )
+        .add_system(systems::camera::rotate_camera.before(systems::camera::move_camera))
         .add_system(systems::camera::move_camera)
         .add_system(systems::movement::keyboard_input)
         .run();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,9 @@
-use bevy::{prelude::*, render::render_resource::{TextureDimension, TextureFormat, Extent3d}};
+use bevy::{
+    prelude::*,
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+};
 
-use self::actor_types::{Player, Camera};
+use self::actor_types::{Camera, Player};
 pub mod actor_types;
 
 pub fn create_actors(
@@ -9,54 +12,49 @@ pub fn create_actors(
     mut images: ResMut<Assets<Image>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let camera_entity =
-        commands.spawn(
-            Camera3dBundle {
-                transform: Transform::from_xyz(-5.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            }
-        ).id();
+    let camera_entity = commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(-5.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        })
+        .id();
 
-    let player_entity = commands.spawn(
-        PbrBundle {
+    let player_entity = commands
+        .spawn(PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.0, 0.6).into()),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..default()
-        }
-    ).add_child(camera_entity).id();
+        })
+        .add_child(camera_entity)
+        .id();
 
-    commands.insert_resource(
-        Player(player_entity)
-    );
+    commands.insert_resource(Player(player_entity));
 
     // camera
-    commands.insert_resource(
-        Camera(camera_entity)
-    );
+    commands.insert_resource(Camera(camera_entity));
 
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(10.0).into()),
-        material: materials.add(StandardMaterial {
-            base_color_texture: Some(images.add(floor_texture())),
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(shape::Plane::from_size(10.0).into()),
+            material: materials.add(StandardMaterial {
+                base_color_texture: Some(images.add(floor_texture())),
+                ..default()
+            }),
             ..default()
-        }),
-        ..default()
-    })
+        })
         .add_child(player_entity);
 
     // light
-    commands.spawn(
-        PointLightBundle {
-            point_light: PointLight {
-                intensity: 1500.0,
-                shadows_enabled: true,
-                ..default()
-            },
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
             ..default()
-        }
-    );
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
 }
 
 const IMAGE_PIXELS: [u8; 16] = [255, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 255, 255];

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -12,7 +12,7 @@ pub fn create_actors(
     let camera_entity =
         commands.spawn(
             Camera3dBundle {
-                transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+                transform: Transform::from_xyz(-5.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
                 ..default()
             }
         ).id();
@@ -21,7 +21,7 @@ pub fn create_actors(
         PbrBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
             material: materials.add(Color::rgb(0.8, 0.0, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 0.5, 1.0),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..default()
         }
     ).add_child(camera_entity).id();

--- a/src/setup/actor_types.rs
+++ b/src/setup/actor_types.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Resource, Entity};
+use bevy::prelude::{Entity, Resource};
 
 #[derive(Resource)]
 pub struct Player(pub Entity);

--- a/src/systems/camera.rs
+++ b/src/systems/camera.rs
@@ -1,13 +1,13 @@
+use bevy::input::mouse::MouseMotion;
 use bevy::prelude::*;
-use bevy::input::mouse::{ MouseMotion };
 
-use crate::setup::actor_types::{ Camera, Player };
+use crate::setup::actor_types::{Camera, Player};
 
 pub fn rotate_camera(
     mouse_input: Res<Input<MouseButton>>,
     camera: Res<Camera>,
     mut motion_event: EventReader<MouseMotion>,
-    mut transforms: Query<&mut Transform>
+    mut transforms: Query<&mut Transform>,
 ) {
     if mouse_input.any_pressed([MouseButton::Right]) {
         for movement in motion_event.iter() {
@@ -26,25 +26,22 @@ pub fn move_camera(
     camera: Res<Camera>,
     mouse_input: Res<Input<MouseButton>>,
     mut motion_event: EventReader<MouseMotion>,
-    mut transforms: Query<&mut Transform>
+    mut transforms: Query<&mut Transform>,
 ) {
     let player_transform = transforms.get(player.0).unwrap().clone();
     if mouse_input.any_pressed([MouseButton::Left]) {
         for movement in motion_event.iter() {
             let mut new_transform = transforms.get_mut(camera.0).unwrap();
-            let xz_rotation = Vec2::new(
-                new_transform.translation.x,
-                new_transform.translation.z
-            ).rotate(Vec2::from_angle(movement.delta.x / 10.0));
-            let zy_rotation = Vec2::new(xz_rotation[1], new_transform.translation.y).rotate(
-                Vec2::from_angle(
+            let xz_rotation = Vec2::new(new_transform.translation.x, new_transform.translation.z)
+                .rotate(Vec2::from_angle(movement.delta.x / 10.0));
+            let zy_rotation =
+                Vec2::new(xz_rotation[1], new_transform.translation.y).rotate(Vec2::from_angle(
                     (if xz_rotation[1].is_sign_negative() {
                         -movement.delta.y
                     } else {
                         movement.delta.y
-                    }) / 10.0
-                )
-            );
+                    }) / 10.0,
+                ));
 
             new_transform.translation.x = xz_rotation[0];
             new_transform.translation.z = xz_rotation[1];

--- a/src/systems/camera.rs
+++ b/src/systems/camera.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::input::mouse::{MouseMotion};
 
-use crate::setup::actor_types::{Camera};
+use crate::setup::actor_types::{Camera, Player};
 
 pub fn rotate_camera(
     mouse_input: Res<Input<MouseButton>>,
@@ -18,5 +18,27 @@ pub fn rotate_camera(
     
             new_transform.look_to(forward, Vec3::Y);
         }
+    }
+}
+
+
+pub fn move_camera(
+    player: Res<Player>,
+    camera: Res<Camera>,
+    mut motion_event: EventReader<MouseMotion>,
+    mut transforms: Query<&mut Transform>
+) { 
+    let player_transform = transforms.get(player.0).unwrap().clone();
+
+    for movement in motion_event.iter(){
+        let mut new_transform = transforms.get_mut(camera.0).unwrap();
+        let xz = Vec2::new(new_transform.translation.x, new_transform.translation.z).rotate(Vec2::from_angle(movement.delta.x / 10.00));
+        let xy = Vec2::new(xz[0], new_transform.translation.y).rotate(Vec2::from_angle(-movement.delta.y / 10.00));
+
+        new_transform.translation.x = xy[0];
+        new_transform.translation.y = xy[1];
+        new_transform.translation.z = xz[1];
+        
+        new_transform.look_at(player_transform.translation, Vec3::Y);
     }
 }

--- a/src/systems/camera.rs
+++ b/src/systems/camera.rs
@@ -1,44 +1,56 @@
 use bevy::prelude::*;
-use bevy::input::mouse::{MouseMotion};
+use bevy::input::mouse::{ MouseMotion };
 
-use crate::setup::actor_types::{Camera, Player};
+use crate::setup::actor_types::{ Camera, Player };
 
 pub fn rotate_camera(
     mouse_input: Res<Input<MouseButton>>,
     camera: Res<Camera>,
     mut motion_event: EventReader<MouseMotion>,
     mut transforms: Query<&mut Transform>
-) { 
+) {
     if mouse_input.any_pressed([MouseButton::Right]) {
-        for movement in motion_event.iter(){
+        for movement in motion_event.iter() {
             let mut new_transform = transforms.get_mut(camera.0).unwrap();
             new_transform.rotate_y((-movement.delta.x).to_radians());
             new_transform.rotate_x(movement.delta.y.to_radians());
             let forward = new_transform.forward();
-    
+
             new_transform.look_to(forward, Vec3::Y);
         }
     }
 }
 
-
 pub fn move_camera(
     player: Res<Player>,
     camera: Res<Camera>,
+    mouse_input: Res<Input<MouseButton>>,
     mut motion_event: EventReader<MouseMotion>,
     mut transforms: Query<&mut Transform>
-) { 
+) {
     let player_transform = transforms.get(player.0).unwrap().clone();
+    if mouse_input.any_pressed([MouseButton::Left]) {
+        for movement in motion_event.iter() {
+            let mut new_transform = transforms.get_mut(camera.0).unwrap();
+            let xz_rotation = Vec2::new(
+                new_transform.translation.x,
+                new_transform.translation.z
+            ).rotate(Vec2::from_angle(movement.delta.x / 10.0));
+            let zy_rotation = Vec2::new(xz_rotation[1], new_transform.translation.y).rotate(
+                Vec2::from_angle(
+                    (if xz_rotation[1].is_sign_negative() {
+                        -movement.delta.y
+                    } else {
+                        movement.delta.y
+                    }) / 10.0
+                )
+            );
 
-    for movement in motion_event.iter(){
-        let mut new_transform = transforms.get_mut(camera.0).unwrap();
-        let xz = Vec2::new(new_transform.translation.x, new_transform.translation.z).rotate(Vec2::from_angle(movement.delta.x / 10.00));
-        let xy = Vec2::new(xz[0], new_transform.translation.y).rotate(Vec2::from_angle(-movement.delta.y / 10.00));
+            new_transform.translation.x = xz_rotation[0];
+            new_transform.translation.z = xz_rotation[1];
 
-        new_transform.translation.x = xy[0];
-        new_transform.translation.y = xy[1];
-        new_transform.translation.z = xz[1];
-        
-        new_transform.look_at(player_transform.translation, Vec3::Y);
+            new_transform.translation.y = zy_rotation[1].clamp(0.0, 10.0);
+            new_transform.look_at(player_transform.translation, Vec3::Y);
+        }
     }
 }

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,2 +1,2 @@
-pub mod movement;
 pub mod camera;
+pub mod movement;

--- a/src/systems/movement.rs
+++ b/src/systems/movement.rs
@@ -1,24 +1,24 @@
-use bevy::prelude::{Input, KeyCode, Res};
+use bevy::prelude::{Input, KeyCode, MouseButton, Res};
 
 const MOVE_STEP: i8 = 10;
 
-pub fn keyboard_input(input: Res<Input<KeyCode>>){
+pub fn keyboard_input(key_input: Res<Input<KeyCode>>) {
     println!("NEW FRAME");
 
-    for key in input.get_pressed() {
+    for key in key_input.get_pressed() {
         match key {
             KeyCode::W => {
                 println!("W PRESSED");
-            },
+            }
             KeyCode::S => {
                 println!("S PRESSED");
-            },
+            }
             KeyCode::A => {
                 println!("A PRESSED");
-            },
+            }
             KeyCode::D => {
                 println!("D PRESSED");
-            },
+            }
             _ => (),
         }
     }


### PR DESCRIPTION
Enables camera rotation around player when left mouse button is held.

User can: 
* Increase / decrease height of the camera
* Rotate camera 360 deg while keeping camera sight vector pointed at player

    > TODO: honor the sight vector set by camera rotation system